### PR TITLE
Fix package entrypoints and relay publish failures

### DIFF
--- a/.changeset/honest-relays-publish.md
+++ b/.changeset/honest-relays-publish.md
@@ -1,0 +1,5 @@
+---
+"nostr-cs": patch
+---
+
+Fix the published package entrypoints to load from `dist` and surface relay publish failures when no target relay accepts an event.

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "description": "Embeddable customer-support SDK over Nostr — tickets, replies, DMs, CSAT, end-to-end encrypted via NIP-44 + NIP-17.",
   "license": "MIT",
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/src/infrastructure/adapters/outbound/SimplePoolProfileAdapter.ts
+++ b/src/infrastructure/adapters/outbound/SimplePoolProfileAdapter.ts
@@ -4,6 +4,7 @@ import type { ProfilePort } from '../../../application/ports/outbound/ProfilePor
 import type { KeyProvider } from '../../../application/ports/outbound/KeyProvider.js'
 import { RelaySet } from '../../../domain/value-objects/RelaySet.js'
 import { NostrProfile } from '../../../domain/entities/NostrProfile.js'
+import { publishToAtLeastOneRelay } from './publishToAtLeastOneRelay.js'
 
 export class SimplePoolProfileAdapter implements ProfilePort {
   constructor(
@@ -30,7 +31,7 @@ export class SimplePoolProfileAdapter implements ProfilePort {
       content: '',
       created_at: Math.floor(Date.now() / 1000),
     })
-    await Promise.any(this.pool.publish(targetRelays, signed as NtEvent)).catch(() => {})
+    await publishToAtLeastOneRelay(this.pool, targetRelays, signed as NtEvent)
   }
 
   async fetchDMRelays(pubkey: string): Promise<string[]> {
@@ -53,7 +54,7 @@ export class SimplePoolProfileAdapter implements ProfilePort {
       content: '',
       created_at: Math.floor(Date.now() / 1000),
     })
-    await Promise.any(this.pool.publish(targetRelays, signed as NtEvent)).catch(() => {})
+    await publishToAtLeastOneRelay(this.pool, targetRelays, signed as NtEvent)
   }
 
   async fetchProfile(pubkey: string, hintRelays?: string[]): Promise<NostrProfile> {
@@ -96,6 +97,6 @@ export class SimplePoolProfileAdapter implements ProfilePort {
       }),
       created_at: Math.floor(Date.now() / 1000),
     })
-    await Promise.any(this.pool.publish(targetRelays, signed as NtEvent)).catch(() => {})
+    await publishToAtLeastOneRelay(this.pool, targetRelays, signed as NtEvent)
   }
 }

--- a/src/infrastructure/adapters/outbound/SimplePoolRelayAdapter.ts
+++ b/src/infrastructure/adapters/outbound/SimplePoolRelayAdapter.ts
@@ -9,6 +9,7 @@ import type {
   UnsignedEvent,
 } from '../../../application/ports/outbound/NostrEventPort.js'
 import type { KeyProvider } from '../../../application/ports/outbound/KeyProvider.js'
+import { publishToAtLeastOneRelay } from './publishToAtLeastOneRelay.js'
 
 export class SimplePoolRelayAdapter implements NostrEventPort {
   constructor(
@@ -27,12 +28,7 @@ export class SimplePoolRelayAdapter implements NostrEventPort {
         : await this.keyProvider.sign(event)
 
     const relays = targetRelays && targetRelays.length > 0 ? targetRelays : this.defaultRelays
-    const results = this.pool.publish(relays, signed as NtEvent)
-    try {
-      await Promise.any(results)
-    } catch {
-      /* every relay rejected — swallow; caller observes delivery via subscriptions */
-    }
+    await publishToAtLeastOneRelay(this.pool, relays, signed as NtEvent)
     return signed
   }
 

--- a/src/infrastructure/adapters/outbound/publishToAtLeastOneRelay.ts
+++ b/src/infrastructure/adapters/outbound/publishToAtLeastOneRelay.ts
@@ -1,0 +1,55 @@
+import type { Event as NtEvent } from 'nostr-tools/core'
+import type { SimplePool } from 'nostr-tools/pool'
+import { normalizeURL } from 'nostr-tools/utils'
+
+export async function publishToAtLeastOneRelay(
+  pool: SimplePool,
+  relays: string[],
+  event: NtEvent,
+): Promise<void> {
+  const normalizedRelays = relays.map(normalizeURL)
+
+  await Promise.any(
+    normalizedRelays.map((url, index, relayList) =>
+      publishToRelay(pool, url, index, relayList, event),
+    ),
+  )
+}
+
+async function publishToRelay(
+  pool: SimplePool,
+  url: string,
+  index: number,
+  relayList: string[],
+  event: NtEvent,
+): Promise<string> {
+  if (relayList.indexOf(url) !== index) {
+    throw new Error(`duplicate relay url: ${url}`)
+  }
+
+  if (pool.allowConnectingToRelay?.(url, ['write', event]) === false) {
+    throw new Error(`connection skipped by allowConnectingToRelay: ${url}`)
+  }
+
+  let relay: Awaited<ReturnType<SimplePool['ensureRelay']>>
+  try {
+    relay = await pool.ensureRelay(url, {
+      connectionTimeout: pool.maxWaitForConnection,
+    })
+  } catch (error) {
+    pool.onRelayConnectionFailure?.(url)
+    throw error
+  }
+
+  const reason = await relay.publish(event)
+  if (pool.trackRelays) {
+    let seen = pool.seenOn.get(event.id)
+    if (!seen) {
+      seen = new Set()
+      pool.seenOn.set(event.id, seen)
+    }
+    seen.add(relay)
+  }
+
+  return reason
+}

--- a/test/infrastructure/adapters/outbound/SimplePoolProfileAdapter.test.ts
+++ b/test/infrastructure/adapters/outbound/SimplePoolProfileAdapter.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test'
+import type { SimplePool } from 'nostr-tools/pool'
+import { SimplePoolProfileAdapter } from '../../../../src/infrastructure/adapters/outbound/SimplePoolProfileAdapter.js'
+import { NostrProfile } from '../../../../src/domain/entities/NostrProfile.js'
+import { RelaySet } from '../../../../src/domain/value-objects/RelaySet.js'
+import { makeKeyProvider } from '../../../support/mocks.js'
+
+function makePool(results: Array<() => Promise<string>>): SimplePool {
+  return {
+    maxWaitForConnection: 3000,
+    seenOn: new Map(),
+    trackRelays: false,
+    ensureRelay: async () => ({
+      publish: () => {
+        const result = results.shift()
+        if (!result) throw new Error('unexpected publish')
+        return result()
+      },
+    }),
+    querySync: async () => [],
+  } as unknown as SimplePool
+}
+
+function makeConnectionFailurePool(): SimplePool {
+  return {
+    maxWaitForConnection: 3000,
+    seenOn: new Map(),
+    trackRelays: false,
+    ensureRelay: async () => {
+      throw new Error('connection failed')
+    },
+    querySync: async () => [],
+  } as unknown as SimplePool
+}
+
+describe('SimplePoolProfileAdapter publish methods', () => {
+  test('publishRelaySet rejects when every relay publish fails', async () => {
+    const { port: keyProvider } = makeKeyProvider({ pubkey: 'pk-customer' })
+    const adapter = new SimplePoolProfileAdapter(
+      makePool([() => Promise.reject(new Error('relay failed'))]),
+      keyProvider,
+      ['wss://relay.example'],
+    )
+
+    await expect(adapter.publishRelaySet(
+      new RelaySet(['wss://write.example'], ['wss://read.example']),
+      ['wss://relay.example'],
+    )).rejects.toThrow()
+  })
+
+  test('publishRelaySet rejects when every relay connection fails before publish', async () => {
+    const { port: keyProvider } = makeKeyProvider({ pubkey: 'pk-customer' })
+    const adapter = new SimplePoolProfileAdapter(
+      makeConnectionFailurePool(),
+      keyProvider,
+      ['wss://relay.example'],
+    )
+
+    await expect(adapter.publishRelaySet(
+      new RelaySet(['wss://write.example'], ['wss://read.example']),
+      ['wss://relay.example'],
+    )).rejects.toThrow()
+  })
+
+  test('publishDMRelays rejects when every relay publish fails', async () => {
+    const { port: keyProvider } = makeKeyProvider({ pubkey: 'pk-customer' })
+    const adapter = new SimplePoolProfileAdapter(
+      makePool([() => Promise.reject(new Error('relay failed'))]),
+      keyProvider,
+      ['wss://relay.example'],
+    )
+
+    await expect(adapter.publishDMRelays(
+      ['wss://dm.example'],
+      ['wss://relay.example'],
+    )).rejects.toThrow()
+  })
+
+  test('publishProfile rejects when every relay publish fails', async () => {
+    const { port: keyProvider } = makeKeyProvider({ pubkey: 'pk-customer' })
+    const adapter = new SimplePoolProfileAdapter(
+      makePool([() => Promise.reject(new Error('relay failed'))]),
+      keyProvider,
+      ['wss://relay.example'],
+    )
+
+    const profile = new NostrProfile(
+      'pk-customer',
+      'Alice',
+      '',
+      '',
+      'customer',
+      new RelaySet(['wss://write.example'], ['wss://read.example']),
+    )
+
+    await expect(adapter.publishProfile(profile, ['wss://relay.example'])).rejects.toThrow()
+  })
+})

--- a/test/infrastructure/adapters/outbound/SimplePoolRelayAdapter.test.ts
+++ b/test/infrastructure/adapters/outbound/SimplePoolRelayAdapter.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test'
+import type { SimplePool } from 'nostr-tools/pool'
+import { SimplePoolRelayAdapter } from '../../../../src/infrastructure/adapters/outbound/SimplePoolRelayAdapter.js'
+import { makeKeyProvider } from '../../../support/mocks.js'
+
+function makePool(results: Array<() => Promise<string>>): SimplePool {
+  return {
+    maxWaitForConnection: 3000,
+    seenOn: new Map(),
+    trackRelays: false,
+    ensureRelay: async () => ({
+      publish: () => {
+        const result = results.shift()
+        if (!result) throw new Error('unexpected publish')
+        return result()
+      },
+    }),
+    subscribeMany: () => ({ close: () => {} }),
+  } as unknown as SimplePool
+}
+
+function makeConnectionFailurePool(): SimplePool {
+  return {
+    maxWaitForConnection: 3000,
+    seenOn: new Map(),
+    trackRelays: false,
+    ensureRelay: async () => {
+      throw new Error('connection failed')
+    },
+    subscribeMany: () => ({ close: () => {} }),
+  } as unknown as SimplePool
+}
+
+describe('SimplePoolRelayAdapter.publish', () => {
+  test('returns signed event after at least one relay accepts', async () => {
+    const { port: keyProvider } = makeKeyProvider({ pubkey: 'pk-customer' })
+    const adapter = new SimplePoolRelayAdapter(
+      makePool([
+        () => Promise.reject(new Error('relay-a failed')),
+        () => Promise.resolve('ok'),
+      ]),
+      keyProvider,
+      ['wss://relay-a.example', 'wss://relay-b.example'],
+    )
+
+    const signed = await adapter.publish({
+      kind: 7700,
+      tags: [],
+      content: 'ticket',
+      created_at: 1,
+    })
+
+    expect(signed.pubkey).toBe('pk-customer')
+  })
+
+  test('rejects when every relay publish fails', async () => {
+    const { port: keyProvider } = makeKeyProvider({ pubkey: 'pk-customer' })
+    const adapter = new SimplePoolRelayAdapter(
+      makePool([
+        () => Promise.reject(new Error('relay-a failed')),
+        () => Promise.reject(new Error('relay-b failed')),
+      ]),
+      keyProvider,
+      ['wss://relay-a.example', 'wss://relay-b.example'],
+    )
+
+    await expect(adapter.publish({
+      kind: 7700,
+      tags: [],
+      content: 'ticket',
+      created_at: 1,
+    })).rejects.toThrow()
+  })
+
+  test('rejects when every relay connection fails before publish', async () => {
+    const { port: keyProvider } = makeKeyProvider({ pubkey: 'pk-customer' })
+    const adapter = new SimplePoolRelayAdapter(
+      makeConnectionFailurePool(),
+      keyProvider,
+      ['wss://relay.example'],
+    )
+
+    await expect(adapter.publish({
+      kind: 7700,
+      tags: [],
+      content: 'ticket',
+      created_at: 1,
+    })).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- Point package entrypoints and exports at dist so the published npm package can be imported.
- Replace false-success relay publish handling with an at-least-one-relay-accepted helper.
- Add regression coverage for relay publish and connection failures.
- Add a patch changeset for the next release.

## Verification
- bun run typecheck
- bun test
- bun run build
- node --input-type=module import check
- npm pack --dry-run