### PR TITLE
Release nostr-cs 0.0.3

### DIFF
--- a/.changeset/honest-relays-publish.md
+++ b/.changeset/honest-relays-publish.md
@@ -1,5 +1,0 @@
----
-"nostr-cs": patch
----
-
-Fix the published package entrypoints to load from `dist` and surface relay publish failures when no target relay accepts an event.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nostr-cs
 
+## 0.0.3
+
+### Patch Changes
+
+- e925737: Fix the published package entrypoints to load from `dist` and surface relay publish failures when no target relay accepts an event.
+
 ## 0.0.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostr-cs",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Embeddable customer-support SDK over Nostr — tickets, replies, DMs, CSAT, end-to-end encrypted via NIP-44 + NIP-17.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump nostr-cs to 0.0.3 via changesets.
- Update CHANGELOG for package entrypoint and relay publish failure fixes.
- Consume the patch changeset from the merged fix PR.

## Verification
- bun run typecheck
- bun test
- bun run build
- node --input-type=module import check
- npm pack --dry-run