### PR TITLE
Add relay infrastructure injection

### DIFF
--- a/.changeset/configurable-relay-infrastructure.md
+++ b/.changeset/configurable-relay-infrastructure.md
@@ -1,0 +1,5 @@
+---
+"nostr-cs": patch
+---
+
+Add relay infrastructure injection so host apps can supply their own pool and relay index while preserving default relay discovery behavior.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,40 @@ const client = new CSClient({
 await client.connect()
 ```
 
+### Advanced relay infrastructure
+
+`CSClient` creates its own `SimplePool` and public relay discovery adapter by
+default. Host apps that already manage Nostr relay connections can inject those
+dependencies instead:
+
+```ts
+import { CSClient, type RelayIndexPort } from 'nostr-cs'
+
+const relayIndex: RelayIndexPort = {
+  fetchPublicRelays: async () => ['wss://relay.example'],
+}
+
+const client = new CSClient({
+  key: { type: 'signer', value: keyProvider },
+  relays: { bootstrap: ['wss://relay.example'] },
+  infrastructure: {
+    pool: sharedSimplePool,
+    relayIndex,
+  },
+})
+```
+
+When a pool is injected, `disconnect()` stops SDK subscriptions but does not
+destroy the external pool. This lets apps share WebSocket connections and
+control which discovery sources are queried while preserving the default SDK
+behavior for simple integrations.
+
+An external pool must be paired with an explicit `relayIndex`. This prevents a
+host app from accidentally sending public relay discovery queries to the SDK's
+default monitor relays through a shared pool. If you only need custom public
+relay discovery and do not need pool sharing, inject `relayIndex` without
+`pool`.
+
 ### Customer
 
 ```ts

--- a/src/CSClient.ts
+++ b/src/CSClient.ts
@@ -1,6 +1,8 @@
 import type { KeyProvider } from './application/ports/outbound/KeyProvider.js'
 import type { EventBusPort } from './application/ports/outbound/EventBusPort.js'
+import type { RelayIndexPort } from './application/ports/outbound/RelayIndexPort.js'
 import type { ResolvedRelayConfig } from './application/config/ResolvedRelayConfig.js'
+import type { SimplePool } from 'nostr-tools/pool'
 
 import type {
   CreateTicketParams,
@@ -34,6 +36,28 @@ export interface RelayConfig {
   dm?: string[]
 }
 
+export type CSClientInfrastructure =
+  | {
+      /**
+       * Optional public relay discovery adapter. Supply this when the host app
+       * needs to control discovery sources.
+       */
+      relayIndex?: RelayIndexPort
+      pool?: undefined
+    }
+  | {
+      /**
+       * Externally-owned relay pool. When supplied, CSClient will reuse it and
+       * will not destroy it during disconnect().
+       */
+      pool: SimplePool
+      /**
+       * Required with an external pool so the host app explicitly controls
+       * public relay discovery instead of silently using SDK defaults.
+       */
+      relayIndex: RelayIndexPort
+    }
+
 export interface CSClientConfig {
   key: KeyInput
   relays: RelayConfig
@@ -41,6 +65,7 @@ export interface CSClientConfig {
     name: string
     csRole: 'agent' | 'customer'
   }
+  infrastructure?: CSClientInfrastructure
 }
 
 function resolveRelayConfig(cfg: RelayConfig): ResolvedRelayConfig {
@@ -65,7 +90,12 @@ export class CSClient {
 
   async connect(): Promise<void> {
     const resolved = resolveRelayConfig(this.config.relays)
-    this.container = buildContainer(this.keyProvider, resolved, this.config.profile)
+    this.container = buildContainer(
+      this.keyProvider,
+      resolved,
+      this.config.profile,
+      this.config.infrastructure,
+    )
 
     await this.container.bootstrapUseCase.execute()
 
@@ -80,7 +110,10 @@ export class CSClient {
     if (!this.container) return
     this.container.subscribeAsAgentUseCase.stop()
     this.container.subscribeAsCustomerUseCase.stop()
-    this.container.pool.destroy()
+    if (this.container.ownsPool) {
+      this.container.pool.destroy()
+    }
+    this.container = null
   }
 
   /** Pull events authored by this user that the role's `#p:[me]` subscription

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 export { CSClient } from './CSClient.js'
-export type { CSClientConfig, RelayConfig, KeyInput } from './CSClient.js'
+export type {
+  CSClientConfig,
+  CSClientInfrastructure,
+  RelayConfig,
+  KeyInput,
+} from './CSClient.js'
 
 export { PrivateKeyProvider } from './infrastructure/adapters/outbound/key-providers/PrivateKeyProvider.js'
 export { NIP07KeyProvider } from './infrastructure/adapters/outbound/key-providers/NIP07KeyProvider.js'

--- a/src/infrastructure/adapters/outbound/SimplePoolRelayIndexAdapter.ts
+++ b/src/infrastructure/adapters/outbound/SimplePoolRelayIndexAdapter.ts
@@ -6,12 +6,19 @@ import type {
 } from '../../../application/ports/outbound/RelayIndexPort.js'
 
 export class SimplePoolRelayIndexAdapter implements RelayIndexPort {
-  private static readonly MONITOR_RELAYS = [
+  private static readonly DEFAULT_MONITOR_RELAYS = [
     'wss://relay.nostr.watch',
     'wss://relaypag.es',
   ]
 
-  constructor(private readonly pool: SimplePool) {}
+  private readonly monitorRelays: string[]
+
+  constructor(
+    private readonly pool: SimplePool,
+    monitorRelays: readonly string[] = SimplePoolRelayIndexAdapter.DEFAULT_MONITOR_RELAYS,
+  ) {
+    this.monitorRelays = [...monitorRelays]
+  }
 
   async fetchPublicRelays(filter: RelayIndexFilter = {}): Promise<string[]> {
     const markers: string[] = []
@@ -27,7 +34,7 @@ export class SimplePoolRelayIndexAdapter implements RelayIndexPort {
     }
 
     const events = await this.pool.querySync(
-      SimplePoolRelayIndexAdapter.MONITOR_RELAYS,
+      this.monitorRelays,
       reqFilter,
       { maxWait: 3000 },
     )

--- a/src/infrastructure/di/container.ts
+++ b/src/infrastructure/di/container.ts
@@ -23,9 +23,11 @@ import { Nip59CryptoAdapter } from '../adapters/outbound/Nip59CryptoAdapter.js'
 import { SimplePoolProfileAdapter } from '../adapters/outbound/SimplePoolProfileAdapter.js'
 import { SimplePoolRelayAdapter } from '../adapters/outbound/SimplePoolRelayAdapter.js'
 import { SimplePoolRelayIndexAdapter } from '../adapters/outbound/SimplePoolRelayIndexAdapter.js'
+import type { RelayIndexPort } from '../../application/ports/outbound/RelayIndexPort.js'
 
 export interface DIContainer {
   pool: SimplePool
+  ownsPool: boolean
   eventBus: EventBusPort
   createTicketUseCase: CreateTicketUseCase
   replyTicketUseCase: ReplyTicketUseCase
@@ -40,23 +42,35 @@ export interface DIContainer {
   bootstrapUseCase: BootstrapUseCase
 }
 
+export type ContainerInfrastructure =
+  | { relayIndex?: RelayIndexPort; pool?: undefined }
+  | { pool: SimplePool; relayIndex: RelayIndexPort }
+
 export function buildContainer(
   keyProvider: KeyProvider,
   relays: ResolvedRelayConfig,
   profileMeta?: { name: string; csRole: 'agent' | 'customer' },
+  infrastructure: ContainerInfrastructure = {},
 ): DIContainer {
-  const pool = new SimplePool()
+  const hasExternalPool = infrastructure.pool !== undefined
+  if (hasExternalPool && infrastructure.relayIndex === undefined) {
+    throw new Error('relayIndex is required when injecting an external pool')
+  }
+
+  const pool = infrastructure.pool ?? new SimplePool()
+  const ownsPool = !hasExternalPool
 
   const relayPort = new SimplePoolRelayAdapter(pool, keyProvider, relays.read)
   const cryptoPort = new Nip59CryptoAdapter(keyProvider)
   const profilePort = new SimplePoolProfileAdapter(pool, keyProvider, relays.bootstrap)
-  const relayIndexPort = new SimplePoolRelayIndexAdapter(pool)
+  const relayIndexPort = infrastructure.relayIndex ?? new SimplePoolRelayIndexAdapter(pool)
   const eventBus = new InMemoryEventBus()
 
   const relayDiscovery = new RelayDiscoveryService(profilePort, relays.bootstrap)
 
   return {
     pool,
+    ownsPool,
     eventBus,
     createTicketUseCase: new CreateTicketUseCase(
       relayPort,

--- a/test/CSClient.infrastructure.test.ts
+++ b/test/CSClient.infrastructure.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test'
+import type { Event as NtEvent } from 'nostr-tools/core'
+import type { Filter } from 'nostr-tools/filter'
+import type { SimplePool } from 'nostr-tools/pool'
+import { CSClient } from '../src/CSClient.js'
+import type { CSClientInfrastructure } from '../src/CSClient.js'
+import type { RelayIndexPort } from '../src/application/ports/outbound/RelayIndexPort.js'
+import { makeKeyProvider } from './support/mocks.js'
+
+interface RecordingPool extends SimplePool {
+  destroyed: number
+  publishRelays: string[]
+  queryRelays: string[][]
+  subscribeRelays: string[][]
+}
+
+function makeRecordingPool(): RecordingPool {
+  const pool = {
+    maxWaitForConnection: 3000,
+    seenOn: new Map(),
+    trackRelays: false,
+    destroyed: 0,
+    publishRelays: [] as string[],
+    queryRelays: [] as string[][],
+    subscribeRelays: [] as string[][],
+    ensureRelay: async (url: string) => ({
+      publish: async (_event: NtEvent) => {
+        pool.publishRelays.push(url)
+        return 'ok'
+      },
+    }),
+    querySync: async (relays: string[], _filter: Filter) => {
+      pool.queryRelays.push(relays)
+      return []
+    },
+    subscribeMany: (relays: string[]) => {
+      pool.subscribeRelays.push(relays)
+      return { close: () => {} }
+    },
+    destroy: () => {
+      pool.destroyed += 1
+    },
+  } as unknown as RecordingPool
+
+  return pool
+}
+
+describe('CSClient infrastructure injection', () => {
+  test('uses injected relay index and does not query default relay index adapter', async () => {
+    const pool = makeRecordingPool()
+    const relayIndexCalls: unknown[] = []
+    const relayIndex: RelayIndexPort = {
+      fetchPublicRelays: async (filter) => {
+        relayIndexCalls.push(filter)
+        return ['wss://public.example']
+      },
+    }
+    const { port: keyProvider } = makeKeyProvider({ pubkey: 'pk-customer' })
+
+    const client = new CSClient({
+      key: { type: 'signer', value: keyProvider },
+      relays: {
+        bootstrap: ['wss://bootstrap.example'],
+        write: ['wss://write.example'],
+        read: ['wss://read.example'],
+        dm: [],
+      },
+      infrastructure: { pool, relayIndex },
+    })
+
+    await client.connect()
+    await client.disconnect()
+
+    expect(relayIndexCalls).toHaveLength(1)
+    expect(pool.queryRelays).toEqual([])
+    expect(pool.publishRelays).toContain('wss://bootstrap.example/')
+    expect(pool.publishRelays).toContain('wss://public.example/')
+  })
+
+  test('does not destroy externally supplied pool on disconnect', async () => {
+    const pool = makeRecordingPool()
+    const { port: keyProvider } = makeKeyProvider({ pubkey: 'pk-customer' })
+
+    const client = new CSClient({
+      key: { type: 'signer', value: keyProvider },
+      relays: {
+        bootstrap: ['wss://bootstrap.example'],
+        write: ['wss://write.example'],
+        read: ['wss://read.example'],
+        dm: [],
+      },
+      infrastructure: {
+        pool,
+        relayIndex: { fetchPublicRelays: async () => [] },
+      },
+    })
+
+    await client.connect()
+    await client.disconnect()
+
+    expect(pool.destroyed).toBe(0)
+  })
+
+  test('requires explicit relay index when an external pool is supplied', async () => {
+    const pool = makeRecordingPool()
+    const { port: keyProvider } = makeKeyProvider({ pubkey: 'pk-customer' })
+
+    const client = new CSClient({
+      key: { type: 'signer', value: keyProvider },
+      relays: {
+        bootstrap: ['wss://bootstrap.example'],
+        write: ['wss://write.example'],
+        read: ['wss://read.example'],
+        dm: [],
+      },
+      infrastructure: { pool } as unknown as CSClientInfrastructure,
+    })
+
+    await expect(client.connect()).rejects.toThrow(
+      'relayIndex is required when injecting an external pool',
+    )
+  })
+})

--- a/test/infrastructure/adapters/outbound/SimplePoolRelayIndexAdapter.test.ts
+++ b/test/infrastructure/adapters/outbound/SimplePoolRelayIndexAdapter.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test'
+import type { Event as NtEvent } from 'nostr-tools/core'
+import type { Filter } from 'nostr-tools/filter'
+import type { SimplePool } from 'nostr-tools/pool'
+import { SimplePoolRelayIndexAdapter } from '../../../../src/infrastructure/adapters/outbound/SimplePoolRelayIndexAdapter.js'
+
+interface RecordingPool extends SimplePool {
+  queries: Array<{ relays: string[]; filter: Filter }>
+}
+
+function makePool(): RecordingPool {
+  const pool = {
+    maxWaitForConnection: 3000,
+    seenOn: new Map(),
+    trackRelays: false,
+    queries: [] as Array<{ relays: string[]; filter: Filter }>,
+    querySync: async (relays: string[], filter: Filter) => {
+      pool.queries.push({ relays, filter })
+      return [
+        {
+          kind: 30166,
+          tags: [
+            ['d', 'wss://relay-one.example'],
+            ['d', 'https://not-a-relay.example'],
+          ],
+          content: '',
+          created_at: 1,
+          id: 'event-id',
+          pubkey: 'pubkey',
+          sig: 'sig',
+        } as NtEvent,
+      ]
+    },
+  } as unknown as RecordingPool
+
+  return pool
+}
+
+describe('SimplePoolRelayIndexAdapter', () => {
+  test('queries caller-provided monitor relays', async () => {
+    const pool = makePool()
+    const adapter = new SimplePoolRelayIndexAdapter(pool, [
+      'wss://monitor-a.example',
+      'wss://monitor-b.example',
+    ])
+
+    const relays = await adapter.fetchPublicRelays({
+      noPayment: true,
+      noAuth: true,
+      limit: 5,
+    })
+
+    expect(pool.queries[0]!.relays).toEqual([
+      'wss://monitor-a.example',
+      'wss://monitor-b.example',
+    ])
+    expect(pool.queries[0]!.filter.kinds).toEqual([30166])
+    expect(pool.queries[0]!.filter.limit).toBe(5)
+    expect((pool.queries[0]!.filter as unknown as Record<string, string[]>)['#R'])
+      .toEqual(['!payment', '!auth'])
+    expect(relays).toEqual(['wss://relay-one.example'])
+  })
+})


### PR DESCRIPTION
## Summary
- allow CSClient callers to inject a shared SimplePool and RelayIndexPort
- require explicit relayIndex when an external pool is injected to avoid hidden default monitor egress
- keep default SDK behavior for simple integrations and document advanced relay infrastructure

## Verification
- bun run typecheck
- bun test
- bun run build
- node --input-type=module -e "const mod = await import('./dist/index.js'); console.log(typeof mod.CSClient)"
- npm_config_cache=/tmp/nostr-cs-npm-cache npm pack --dry-run --json
- git diff --check
- specialist read-only review: no findings