### PR TITLE
Release nostr-cs 0.0.4

### DIFF
--- a/.changeset/configurable-relay-infrastructure.md
+++ b/.changeset/configurable-relay-infrastructure.md
@@ -1,5 +1,0 @@
----
-"nostr-cs": patch
----
-
-Add relay infrastructure injection so host apps can supply their own pool and relay index while preserving default relay discovery behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nostr-cs
 
+## 0.0.4
+
+### Patch Changes
+
+- 4e03d43: Add relay infrastructure injection so host apps can supply their own pool and relay index while preserving default relay discovery behavior.
+
 ## 0.0.3
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostr-cs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Embeddable customer-support SDK over Nostr — tickets, replies, DMs, CSAT, end-to-end encrypted via NIP-44 + NIP-17.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump nostr-cs to 0.0.4
- update changelog for relay infrastructure injection
- remove consumed changeset

## Verification
- bun run typecheck
- bun test
- bun run build
- node --input-type=module -e "const mod = await import('./dist/index.js'); console.log(typeof mod.CSClient)"
- npm_config_cache=/tmp/nostr-cs-npm-cache npm pack --dry-run --json
- git diff --check